### PR TITLE
Add FiveForths to the list

### DIFF
--- a/index.html
+++ b/index.html
@@ -322,6 +322,10 @@
           <td><a href="https://github.com/Fittiboy/ziscv">ZISC-V</a></td>
           <td>a RISC-V assembler and simulator, for fun</td>
         </tr>
+        <tr>
+          <td><a href="https://github.com/aw/fiveforths">FiveForths</a></td>
+          <td>a hand-written RISC-V Forth, for fun</td>
+        </tr>
       </tbody>
     </table>
 


### PR DESCRIPTION
Hi,

I've had this website's badge in [my repo's README since 2023](https://github.com/aw/fiveforths/commit/4717efaefc3f60a6926f6aaa4bd7619af60dbaae#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3-R6), but I completely forgot to open a PR to add it. Here we are.

Cheers!